### PR TITLE
qgrid: Updating instructions to install via pip

### DIFF
--- a/installation/no_virtual_environment/installation.md
+++ b/installation/no_virtual_environment/installation.md
@@ -21,6 +21,7 @@ The installations are different for Jupyter Notebook and Jupyter Lab.
 From the terminal, you need to setup the Jupyter Notebook extensions via the following command:
 
 ```bash
+jupyter nbextension install --py qgrid --sys-prefix
 jupyter nbextension enable --py qgrid --sys-prefix
 jupyter nbextension enable --py widgetsnbextension --sys-prefix
 jupyter nbextension install --py bamboolib --sys-prefix


### PR DESCRIPTION
qgrid: Updating the instructions with added step to ensure qgrid is installed before enabling it.

Without installing `qgrid`, trying to enable it will show us the below message:
```
$ jupyter nbextension enable --py qgrid --sys-prefix
Enabling notebook extension qgrid/extension...
      - Validating: problems found:
        - require?  X qgrid/extension
```
after installing:

```
$ jupyter nbextension enable --py qgrid --sys-prefix
Enabling notebook extension qgrid/extension...
      - Validating: OK
```